### PR TITLE
[route] basename 설정

### DIFF
--- a/src/components/Test.tsx
+++ b/src/components/Test.tsx
@@ -1,5 +1,17 @@
+import { Link } from 'react-router-dom';
+
 function Test() {
-  return <div>Hello test world!!</div>;
+  console.log('1');
+  return (
+    <div>
+      Hello test world2!!
+      <div>
+        <Link to="/test2">
+          <button type="button">go to Test2</button>
+        </Link>
+      </div>
+    </div>
+  );
 }
 
 export default Test;

--- a/src/components/Test2.tsx
+++ b/src/components/Test2.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+function Test2() {
+  console.log('2');
+  return (
+    <div>
+      Hello test world!! Two!!{' '}
+      <div>
+        <Link to="/">
+          {' '}
+          <button type="button">go to Test1</button>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default Test2;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Test from '@/components/Test';
+import { RouterProvider } from 'react-router-dom';
 import '@/styles/global.css';
+import router from '@/router';
 
 const container = document.getElementById('root') as HTMLElement;
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <Test />,
-  },
-]);
 
 createRoot(container).render(
   <StrictMode>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter } from 'react-router-dom';
+import Test from '@/components/Test';
+import Test2 from '@/components/Test2';
+
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: <Test />,
+    },
+    {
+      path: '/test2',
+      element: <Test2 />,
+    },
+  ],
+  {
+    basename: '/ShimJaeWon',
+  }
+);
+
+export default router;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
+    publicPath: '/' 
   },
   resolve: {
     modules: [path.resolve(__dirname, 'src'), 'node_modules'],
@@ -71,6 +72,8 @@ module.exports = {
   },
   devServer: {
     hot: true,
+    port: 3000,
+    historyApiFallback: true,
   },
   plugins,
 };


### PR DESCRIPTION
router-dom
- main.tsx에서 createBrowserRouter 분리 추후 route가 늘어날 것을 대비해 분리
- router에 basename 추가 깃허브 페이지의 url에 리포지토리 이름이 기본으로 들어가므로 basename
추가

webpack
- historyApiFallback를 true로 설정 url을 직접 입력해 모든 경로에서 index.html을 다운받도록 설정
- publicPath를 '/'로 설정 basename으로 설정한 경로가 아닌 기본 경로에서 다운받도록 설정